### PR TITLE
Handle contracts return result type check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,3 @@ gemspec
 
 gem "rspec"
 gem "contracts"
-gem "byebug"

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 
 gem "rspec"
 gem "contracts"
+gem "byebug"

--- a/contracts-rspec.gemspec
+++ b/contracts-rspec.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", "~> 2.3"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/lib/contracts/rspec/mocks.rb
+++ b/lib/contracts/rspec/mocks.rb
@@ -4,6 +4,7 @@ module Contracts
       def instance_double(klass, *args)
         super.tap do |double|
           allow(double).to receive(:is_a?).with(klass).and_return(true)
+          allow(double).to receive(:is_a?).with(ParamContractError).and_return(klass.is_a?(ParamContractError))
         end
       end
     end

--- a/lib/contracts/rspec/version.rb
+++ b/lib/contracts/rspec/version.rb
@@ -1,5 +1,5 @@
 module Contracts
   module RSpec
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/spec/contracts/rspec/mocks_spec.rb
+++ b/spec/contracts/rspec/mocks_spec.rb
@@ -14,6 +14,11 @@ class Example
   def do_something(something)
     something.call
   end
+
+  Contract String => Something
+  def returns_something
+    Something.new
+  end
 end
 
 RSpec.describe Example do
@@ -21,7 +26,7 @@ RSpec.describe Example do
 
   context "without Contracts::RSpec::Mocks included" do
     it "violates contract" do
-      expect { Example.new.do_something(something) }
+      expect { subject.do_something(something) }
         .to raise_error(ContractError, /Expected: Something/)
     end
   end
@@ -30,7 +35,14 @@ RSpec.describe Example do
     include Contracts::RSpec::Mocks
 
     it "succeeds contract" do
-      expect(Example.new.do_something(something)).to eq(:something_is_done)
+      expect(subject.do_something(something)).to eq(:something_is_done)
+    end
+
+    it "violates return value contract" do
+      something = instance_double(Something)
+      allow(Something).to receive(:new).and_return(something)
+
+      Example.new.returns_something
     end
   end
 end


### PR DESCRIPTION
Contracts gem as of 0.17 checks to see if the result of a method is a `ParamContractError`. This causes an error so I've added an additional line to check if the class is a ParamContractError.