### PR TITLE
v0.3.0 Improved #is_a? mocks

### DIFF
--- a/lib/contracts/rspec/mocks.rb
+++ b/lib/contracts/rspec/mocks.rb
@@ -3,8 +3,9 @@ module Contracts
     module Mocks
       def instance_double(klass, *args)
         super.tap do |double|
-          allow(double).to receive(:is_a?).with(klass).and_return(true)
-          allow(double).to receive(:is_a?).with(ParamContractError).and_return(klass.is_a?(ParamContractError))
+          allow(double).to receive(:is_a?).with(anything) do |other|
+            klass <= other
+          end
         end
       end
     end

--- a/lib/contracts/rspec/version.rb
+++ b/lib/contracts/rspec/version.rb
@@ -1,5 +1,5 @@
 module Contracts
   module RSpec
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end

--- a/spec/contracts/rspec/mocks_spec.rb
+++ b/spec/contracts/rspec/mocks_spec.rb
@@ -1,33 +1,36 @@
-class Something
+class Plant
   include Contracts
 
-  Contract None => :something_is_done
+  Contract None => :success
   def call
-    :something_is_done
+    :success
   end
+end
+
+class Tree < Plant
+end
+
+class Oak < Tree
 end
 
 class Example
   include Contracts
 
-  Contract Something => :something_is_done
-  def do_something(something)
-    something.call
-  end
-
-  Contract String => Something
-  def returns_something
-    Something.new
+  Contract Plant => :success
+  def test(instance)
+    instance.call
   end
 end
 
 RSpec.describe Example do
-  let(:something) { instance_double(Something, call: :something_is_done) }
+  let(:plant) { instance_double(Plant, call: :success) }
+  let(:tree) { instance_double(Tree, call: :success) }
+  let(:oak) { instance_double(Oak, call: :success) }
 
   context "without Contracts::RSpec::Mocks included" do
     it "violates contract" do
-      expect { subject.do_something(something) }
-        .to raise_error(ContractError, /Expected: Something/)
+      expect { subject.test(plant) }
+        .to raise_error(ContractError, /Expected: Plant/)
     end
   end
 
@@ -35,14 +38,19 @@ RSpec.describe Example do
     include Contracts::RSpec::Mocks
 
     it "succeeds contract" do
-      expect(subject.do_something(something)).to eq(:something_is_done)
+      expect(subject.test(plant)).to eq(:success)
     end
 
-    it "violates return value contract" do
-      something = instance_double(Something)
-      allow(Something).to receive(:new).and_return(something)
+    context "when doubled class is a subclass of contract class" do
+      it "succeeds contract" do
+        expect(subject.test(tree)).to eq(:success)
+      end
+    end
 
-      Example.new.returns_something
+    context "when doubled class is a descendant of contract class" do
+      it "succeeds contract" do
+        expect(subject.test(oak)).to eq(:success)
+      end
     end
   end
 end

--- a/spec/contracts/rspec/mocks_spec.rb
+++ b/spec/contracts/rspec/mocks_spec.rb
@@ -1,4 +1,10 @@
-class Plant
+class Organism
+end
+
+class Eukaryote < Organism
+end
+
+class Plant < Eukaryote
   include Contracts
 
   Contract None => :success
@@ -23,6 +29,8 @@ class Example
 end
 
 RSpec.describe Example do
+  let(:organism) { instance_double(Organism) }
+  let(:eukaryote) { instance_double(Eukaryote) }
   let(:plant) { instance_double(Plant, call: :success) }
   let(:tree) { instance_double(Tree, call: :success) }
   let(:oak) { instance_double(Oak, call: :success) }
@@ -50,6 +58,20 @@ RSpec.describe Example do
     context "when doubled class is a descendant of contract class" do
       it "succeeds contract" do
         expect(subject.test(oak)).to eq(:success)
+      end
+    end
+
+    context "when doubled class is the superclass of contract class" do
+      it "violates contract" do
+        expect { subject.test(eukaryote) }
+          .to raise_error(ContractError, /Expected: Plant/)
+      end
+    end
+
+    context "when doubled class is an ancestor of contract class" do
+      it "violates contract" do
+        expect { subject.test(organism) }
+          .to raise_error(ContractError, /Expected: Plant/)
       end
     end
   end


### PR DESCRIPTION
- Improves `#is_a?` mocks on instance doubles by using more flexible logic
  - Works for identical class, subclass, or any descendant class
- Updates spec to use more sensible class and variable names for the sake of class hierarchy

## Background

I got tired of running into this frustratingly mysterious RSpec failure:

```
#<InstanceDouble(Billing::BiomassInvoiceHelper) (anonymous)> received :is_a? with unexpected arguments
 expected: (ParamContractError)
      got: (ActiveSupport::TimeWithZone)
Diff:
@@ -1 +1 @@
-[ParamContractError]
+[ActiveSupport::TimeWithZone]

Please stub a default value first if message might be received with other args as well.
```

This is because v0.2.0 only explicitly allowed instance doubles to receive `#is_a?` with two possible arguments: the doubled class (`klass`) and `ParamContractError`.

```ruby
allow(double).to receive(:is_a?).with(klass).and_return(true)
allow(double).to receive(:is_a?).with(ParamContractError).and_return(klass.is_a?(ParamContractError))
```
Calling `#is_a?` with any other argument would result in a test failure because the double wasn't mocked for anything else. This led to bizarre test failures that are frustrating because they are orthogonal to the thing under test.

Additionally, there was a logical flaw in the old implementation...

```ruby
klass.is_a?(ParamContractError)
```
This will always return false because `#is_a?` asks an object if it is an _instance_ of a certain class. It does not work for class equality.

```ruby
string = String.new
string.is_a?(String)
=> true # string is indeed an instance of String

String.is_a?(String)
=> false # String is an instance of the Class class so it is not an instance of String
```

For class equality, we can do this:
```ruby
String == String
=> true
```

We can also test if a class is a descendant of another class:
```ruby
String < Object
=> true # String inherits from Object

Object < String
=> false # Object does not inherit from String

String < String
=> false # String does not inherit from String
```

So to adapt this to work for identical classes _or_ descendant classes, we could express it like this:
```ruby
X == Y || X < Y
```
Or more succinctly...
```ruby
X <= Y
```

```ruby
String <= String
=> true

String <= Object
=> true

Object <= String
=> false
```



